### PR TITLE
Add variadic initializer

### DIFF
--- a/Source/ContentNegotiatonMiddleware.swift
+++ b/Source/ContentNegotiatonMiddleware.swift
@@ -40,6 +40,10 @@ public struct ContentNegotiationMiddleware: Middleware {
         case mediaTypeNotFound
     }
 
+    public init(types: MediaType..., mode: Mode = .server) {
+        self.init(mediaTypes: types, mode: mode)
+    }
+
     public init(mediaTypes: [MediaType], mode: Mode = .server) {
         self.mediaTypes = mediaTypes
         self.mode = mode


### PR DESCRIPTION
Right now, ContentNegotiationMiddleware has to be instantiated with either an array of media types or a single media type. Unfortunately Swift does not allow either
- passing an array as a variadic parameter
- having two initializers with the same labels but with one being variadic and one taking an array

hence, the best solution I think is to simply use a different label. It also makes sense IMO since the type `MediaType` is inferred from `JSONMediaType` so `ContentNegotiationMiddleware(mediaTypes: [JSONMediaType()])` is actually less correct than `ContentNegotiationMiddleware(types: JSONMediaType())` (IMO). 
